### PR TITLE
scoping fix for `clearScene`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Lathe-R-Beam
 
 Hackathon project from [@makenai](http://twitter.com/makenai) and [@noopkat](http://twitter.com/nookat), an interactive lathing tool for exporting and 3D printing.
 
-View a demo at [http://amalgamationofcats.com/Lathe-R-Beam](http://amalgamationofcats.com/Lathe-R-Beam)
+View a demo at [http://makenai.github.io/Lathe-R-Beam](http://makenai.github.io/Lathe-R-Beam)
 
 ![latherbeam screengrab](http://f.cl.ly/items/2l2G292V1E0M1B1g3g1B/latherbeam.png)

--- a/js/CanvasBox.js
+++ b/js/CanvasBox.js
@@ -95,11 +95,12 @@ CanvasBox.prototype = {
   },
 
   clearScene : function() {
+    var _this = this;
     var children = this.scene.children.slice(0);
     $.each(children, function(i, child) {
       // Remove everything but the dotted line
       if ( i > 0 )
-        this.scene.remove(child);
+        _this.scene.remove(child);
     }); 
   },
 


### PR DESCRIPTION
I received an email today from someone wanting to report a bug with the scene not clearing properly. I think this is the fix. I committed it against master by accident, apologies 😁 
